### PR TITLE
chown logs directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,5 +18,6 @@ fi
 
 # Fix permissions according to the host user UID and GID
 chown -R "$_UID":"$_GID" /home/joinmarket/.joinmarket
+chown -R "$_UID":"$_GID" /jm/clientserver/scripts/logs
 
 exec gosu joinmarket bash -c "cd /jm/clientserver/scripts && python3 $*"


### PR DESCRIPTION
Some of the scripts seem to need to write to this directory but they're owned by root by default.

```
Traceback (most recent call last):
  File "tumbler.py", line 190, in <module>
    main()
  File "tumbler.py", line 25, in main
    tumble_log = get_tumble_log(logsdir)
  File "/jm/clientserver/jmclient/jmclient/taker_utils.py", line 122, in get_tumble_log
    fileHandler = logging.FileHandler(os.path.join(logsdir, 'TUMBLE.log'))
  File "/usr/lib/python3.7/logging/__init__.py", line 1092, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib/python3.7/logging/__init__.py", line 1121, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
PermissionError: [Errno 13] Permission denied: '/jm/clientserver/scripts/logs/TUMBLE.log'
```