### PR TITLE
Cast to correct types in yg-env.patch

### DIFF
--- a/yg-env.patch
+++ b/yg-env.patch
@@ -24,15 +24,15 @@ index de57cc2..344343e 100644
 -minsize = 1000000         # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
 -size_factor = 0.1         # [percent, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
 -gaplimit = 6
-+ordertype = os.environ.get('JM_ORDERTYPE', 'swreloffer')  # [string, 'swreloffer' or 'swabsoffer'] / which fee type to actually use
-+cjfee_a = os.environ.get('JM_CJFEE_A', 500)             # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
-+cjfee_r = os.environ.get('JM_CJFEE_R', '0.00002')       # [percent, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
-+cjfee_factor = os.environ.get('JM_CJFEE_FACTOR', 0.1)       # [percent, 0-1] / variance around the average fee. Ex: 200 fee, 0.2 var = fee is btw 160-240
-+txfee = os.environ.get('JM_TXFEE', 100)               # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
-+txfee_factor = os.environ.get('JM_TXFEE_FACTOR', 0.3)        # [percent, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
-+minsize = os.environ.get('JM_MINSIZE', 1000000)        # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
-+size_factor = os.environ.get('JM_SIZE_FACTOR', 0.1)         # [percent, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
-+gaplimit = os.environ.get('JM_GAPLIMIT', 6)
++ordertype = os.environ.get('JM_ORDERTYPE', 'swreloffer')     # [string, 'swreloffer' or 'swabsoffer'] / which fee type to actually use
++cjfee_a = int(os.environ.get('JM_CJFEE_A', 500))             # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
++cjfee_r = os.environ.get('JM_CJFEE_R', '0.00002')            # [percent, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
++cjfee_factor = float(os.environ.get('JM_CJFEE_FACTOR', 0.1)) # [percent, 0-1] / variance around the average fee. Ex: 200 fee, 0.2 var = fee is btw 160-240
++txfee = int(os.environ.get('JM_TXFEE', 100))                 # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
++txfee_factor = float(os.environ.get('JM_TXFEE_FACTOR', 0.3)) # [percent, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
++minsize = int(os.environ.get('JM_MINSIZE', 1000000))         # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
++size_factor = float(os.environ.get('JM_SIZE_FACTOR', 0.1))   # [percent, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
++gaplimit = int(os.environ.get('JM_GAPLIMIT', 6))
  
  # end of settings customization
  
@@ -53,15 +53,15 @@ index 2094674..b8648a7 100644
 -cjfee_a = 500
 -cjfee_r = '0.00002'
 -ordertype = 'swreloffer' #'swreloffer' or 'swabsoffer'
-+txfee = os.environ.get('JM_TXFEE', 100)
-+cjfee_a = os.environ.get('JM_CJFEE_A', 500)
++txfee = int(os.environ.get('JM_TXFEE', 100))
++cjfee_a = int(os.environ.get('JM_CJFEE_A', 500))
 +cjfee_r = os.environ.get('JM_CJFEE_R', '0.00002')
 +ordertype = os.environ.get('JM_ORDERTYPE', 'swreloffer') #'swreloffer' or 'swabsoffer'
  nickserv_password = ''
 -max_minsize = 100000
 -gaplimit = 6
-+max_minsize = os.environ.get('JM_MINSIZE', 100000)
-+gaplimit = os.environ.get('JM_GAPLIMIT', 6)
++max_minsize = int(os.environ.get('JM_MINSIZE', 100000))
++gaplimit = int(os.environ.get('JM_GAPLIMIT', 6))
  
  if __name__ == "__main__":
      ygmain(YieldGeneratorBasic, txfee=txfee, cjfee_a=cjfee_a,


### PR DESCRIPTION
If you actually pass in some of these numeric values through environment 
variables, scripts will fail because the values are unexpectedly strings.

```
Traceback (most recent call last):
  File "/jm/clientserver/jmclient/jmclient/yieldgenerator.py", line 29, in __init__
    Maker.__init__(self, wallet_service)
  File "/jm/clientserver/jmclient/jmclient/maker.py", line 32, in __init__
    self.sync_wait_loop.start(2.0)
  File "/usr/local/lib/python3.7/dist-packages/twisted/internet/task.py", line 194, in start
    self()
  File "/usr/local/lib/python3.7/dist-packages/twisted/internet/task.py", line 239, in __call__
    d = defer.maybeDeferred(self.f, *self.a, **self.kw)
--- <exception caught here> ---
  File "/usr/local/lib/python3.7/dist-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/jm/clientserver/jmclient/jmclient/maker.py", line 44, in try_to_create_my_orders
    self.offerlist = self.create_my_orders()
  File "yg-privacyenhanced.py", line 55, in create_my_orders
    randomize_txfee = int(random.uniform(txfee * (1 - float(txfee_factor)),
builtins.TypeError: can't multiply sequence by non-int of type 'float' 
```